### PR TITLE
fix(gui): WebSocket pages - remove duplicate connection-status, handle already-connected socket

### DIFF
--- a/web/templates/batch_live_log.html
+++ b/web/templates/batch_live_log.html
@@ -249,13 +249,18 @@
 
     const socket = window.__socket || io();
 
-    socket.on('connect', function() {
+    function onConnect() {
         connectionDot.classList.add('connected');
         connectionDot.classList.remove('disconnected');
         connectionText.textContent = 'Connected';
         socket.emit('join_batch_jobs');
         socket.emit('join_batch', { batch_id: batchId });
-    });
+    }
+
+    socket.on('connect', onConnect);
+    if (socket.connected) {
+        onConnect();
+    }
 
     socket.on('disconnect', function() {
         connectionDot.classList.remove('connected');

--- a/web/templates/job_status.html
+++ b/web/templates/job_status.html
@@ -206,11 +206,16 @@
 
     const socket = window.__socket || io();
 
-    socket.on('connect', function() {
+    function onConnect() {
         connectionDot.classList.add('connected');
         connectionText.textContent = 'Live';
         socket.emit('join_job', { job_id: jobId });
-    });
+    }
+
+    socket.on('connect', onConnect);
+    if (socket.connected) {
+        onConnect();
+    }
 
     socket.on('disconnect', function() {
         connectionDot.classList.remove('connected');

--- a/web/templates/live_log.html
+++ b/web/templates/live_log.html
@@ -49,12 +49,17 @@
 
     const socket = window.__socket || io();
 
-    socket.on('connect', function() {
+    function onConnect() {
         connectionDot.classList.add('connected');
         connectionDot.classList.remove('disconnected');
         connectionText.textContent = 'Connected';
         socket.emit('join_run', { run_id: runId });
-    });
+    }
+
+    socket.on('connect', onConnect);
+    if (socket.connected) {
+        onConnect();
+    }
 
     socket.on('disconnect', function() {
         connectionDot.classList.remove('connected');

--- a/web/templates/log_view.html
+++ b/web/templates/log_view.html
@@ -242,7 +242,16 @@
             if (!agentDone) {
                 agentPollTimer = setInterval(pollReviewStatus, 3000);
                 const socket = window.__socket || io();
-                socket.on('connect', function() { socket.emit('join_job', { job_id: jobId }); });
+
+                function onConnect() {
+                    socket.emit('join_job', { job_id: jobId });
+                }
+
+                socket.on('connect', onConnect);
+                if (socket.connected) {
+                    onConnect();
+                }
+
                 socket.on('agent_review_ready', function(payload) {
                     if (payload.job_id === jobId) fetchAndShowReview();
                 });


### PR DESCRIPTION
## Summary
Two atomic fixes for migrated WebSocket pages:

1. **Remove duplicate connection-status**: Base layout provides connection indicator in top bar. Remove redundant divs from live_log, batch_live_log, job_status to avoid duplicate IDs.

2. **Handle already-connected socket**: When using window.__socket, socket may already be connected on load. Call onConnect immediately if socket.connected so join_run/join_batch/join_job run without waiting.

Made with [Cursor](https://cursor.com)