### PR TITLE
Fix batch schedule edit: allow editing playbooks and targets

### DIFF
--- a/web/scheduler.py
+++ b/web/scheduler.py
@@ -799,9 +799,18 @@ class ScheduleManager:
 
             # Update allowed fields
             allowed_fields = ['name', 'description', 'target', 'recurrence']
+            if schedule.get('is_batch'):
+                allowed_fields.extend(['playbooks', 'targets'])
             for field in allowed_fields:
                 if field in updates:
                     schedule[field] = updates[field]
+
+            # Update display fields for batch schedules when playbooks/targets change
+            if schedule.get('is_batch'):
+                playbooks = schedule.get('playbooks', [])
+                targets = schedule.get('targets', [])
+                schedule['playbook'] = playbooks[0] if playbooks else None
+                schedule['target'] = f"{len(targets)} targets"
 
             self._save_schedule(schedule_id)
 

--- a/web/templates/schedule_form.html
+++ b/web/templates/schedule_form.html
@@ -101,7 +101,8 @@
     <p><a href="/schedules">&larr; Back to Schedules</a></p>
 
     <form action="{% if edit_mode %}/schedules/{{ schedule.id }}/update{% else %}/schedules/create{% endif %}"
-              method="POST" class="schedule-form" id="scheduleForm">
+              method="POST" class="schedule-form" id="scheduleForm"
+              {% if edit_mode and schedule and schedule.is_batch %}data-edit-batch="true"{% endif %}>
 
             <!-- Hidden fields for batch mode -->
             <input type="hidden" id="is_batch" name="is_batch" value="{{ 'true' if (schedule and schedule.is_batch) or batch_mode else 'false' }}">
@@ -333,14 +334,18 @@
         };
 
         // Initialize from URL params (when coming from main page "Schedule Batch" button)
+        // or from edit mode (batch schedule being edited)
         function initFromUrlParams() {
             const urlParams = new URLSearchParams(window.location.search);
-            if (urlParams.get('batch') === 'true') {
+            const form = document.getElementById('scheduleForm');
+            const isEditBatch = form && form.dataset.editBatch === 'true';
+
+            if (urlParams.get('batch') === 'true' || isEditBatch) {
                 setScheduleMode('batch');
 
-                const playbooks = urlParams.get('playbooks');
-                const targets = urlParams.get('targets');
-                const name = urlParams.get('name');
+                const playbooks = isEditBatch ? (document.getElementById('playbooks_hidden')?.value || '') : urlParams.get('playbooks');
+                const targets = isEditBatch ? (document.getElementById('targets_hidden')?.value || '') : urlParams.get('targets');
+                const name = isEditBatch ? null : urlParams.get('name');
 
                 if (playbooks) {
                     playbooks.split(',').forEach(pb => {


### PR DESCRIPTION
Fixes the inability to edit batch playbooks and targets in a schedule.

**Changes:**
- `edit_schedule`: Pass batch_mode, batch_playbooks, batch_targets, and batch_playbooks_list/batch_targets_list to template for batch schedules
- `update_schedule`: Read playbooks and targets from form for batch schedules, parse comma-separated values and include in updates
- `scheduler.update_schedule`: Add playbooks and targets to allowed fields for batch schedules; update display fields (playbook, target) accordingly
- `schedule_form`: Add data-edit-batch when editing batch schedule; extend initFromUrlParams to populate batch UI from hidden fields in edit mode

Made with [Cursor](https://cursor.com)