### PR TITLE
Add UniFi AP management playbooks

### DIFF
--- a/playbooks/network/unifi/README.md
+++ b/playbooks/network/unifi/README.md
@@ -1,0 +1,18 @@
+# UniFi AP Management Playbooks
+
+This suite of playbooks allows for direct management and monitoring of UniFi Access Points via SSH.
+
+## Prerequisites
+* SSH must be enabled on the APs (configured in the UniFi Controller).
+* An inventory group named `unifi_aps` must be defined.
+
+## Playbooks
+1. **get_config.yml**: Fetches `/tmp/system.cfg` from the AP and saves it to the `logs/` directory.
+2. **get_logs.yml**: Retrieves the last 100 lines of system logs and 50 lines of kernel logs.
+3. **get_stats.yml**: Executes `mca-dump` to gather detailed JSON statistics about clients, traffic, and hardware status.
+
+## Usage
+Run via the web interface or CLI:
+```bash
+./run-playbook.sh playbooks/network/unifi/get_stats.yml unifi_aps
+```

--- a/playbooks/network/unifi/get_config.yml
+++ b/playbooks/network/unifi/get_config.yml
@@ -1,0 +1,18 @@
+---
+- name: Gather UniFi AP Configuration
+  hosts: unifi_aps
+  gather_facts: false
+  tasks:
+    - name: Get current configuration
+      shell: cat /tmp/system.cfg
+      register: ap_config
+
+    - name: Display configuration
+      debug:
+        var: ap_config.stdout_lines
+
+    - name: Save configuration to file
+      copy:
+        content: "{{ ap_config.stdout }}"
+        dest: "logs/unifi_{{ inventory_hostname }}_config.cfg"
+      delegate_to: localhost

--- a/playbooks/network/unifi/get_logs.yml
+++ b/playbooks/network/unifi/get_logs.yml
@@ -1,0 +1,27 @@
+---
+- name: Gather UniFi AP Logs
+  hosts: unifi_aps
+  gather_facts: false
+  tasks:
+    - name: Get system logs
+      shell: tail -n 100 /var/log/messages
+      register: system_logs
+
+    - name: Get kernel logs
+      shell: dmesg | tail -n 50
+      register: kernel_logs
+
+    - name: Display system logs
+      debug:
+        var: system_logs.stdout_lines
+
+    - name: Save logs to file
+      copy:
+        content: |
+          === SYSTEM LOGS ===
+          {{ system_logs.stdout }}
+          
+          === KERNEL LOGS ===
+          {{ kernel_logs.stdout }}
+        dest: "logs/unifi_{{ inventory_hostname }}_logs.txt"
+      delegate_to: localhost

--- a/playbooks/network/unifi/get_stats.yml
+++ b/playbooks/network/unifi/get_stats.yml
@@ -1,0 +1,27 @@
+---
+- name: Gather UniFi AP Usage Stats
+  hosts: unifi_aps
+  gather_facts: false
+  tasks:
+    - name: Get wireless stats (mca-dump)
+      shell: mca-dump
+      register: mca_dump
+
+    - name: Parse dump for key stats
+      set_fact:
+        parsed_stats: "{{ mca_dump.stdout | from_json }}"
+
+    - name: Display usage summary
+      debug:
+        msg:
+          - "Model: {{ parsed_stats.model }}"
+          - "Version: {{ parsed_stats.version }}"
+          - "Uptime: {{ parsed_stats.uptime }}s"
+          - "Memory: {{ parsed_stats.mem_used / 1024 / 1024 | round(2) }}MB / {{ parsed_stats.mem_total / 1024 / 1024 | round(2) }}MB"
+          - "Load: {{ parsed_stats.loadavg }}"
+
+    - name: Save detailed stats to file
+      copy:
+        content: "{{ mca_dump.stdout | from_json | to_nice_json }}"
+        dest: "logs/unifi_{{ inventory_hostname }}_stats.json"
+      delegate_to: localhost


### PR DESCRIPTION
Closes #16. Implements playbooks for gathering config, logs, and usage statistics from UniFi Access Points via SSH.