### PR TITLE
Fix: Improve UniFi compatibility and connection testing

### DIFF
--- a/playbooks/network/unifi/get_config.yml
+++ b/playbooks/network/unifi/get_config.yml
@@ -4,12 +4,12 @@
   gather_facts: false
   tasks:
     - name: Get current configuration
-      shell: cat /tmp/system.cfg
+      raw: cat /tmp/system.cfg
       register: ap_config
 
     - name: Display configuration
       debug:
-        var: ap_config.stdout_lines
+        msg: "{{ ap_config.stdout_lines }}"
 
     - name: Save configuration to file
       copy:

--- a/playbooks/network/unifi/get_logs.yml
+++ b/playbooks/network/unifi/get_logs.yml
@@ -4,16 +4,16 @@
   gather_facts: false
   tasks:
     - name: Get system logs
-      shell: tail -n 100 /var/log/messages
+      raw: tail -n 100 /var/log/messages
       register: system_logs
 
     - name: Get kernel logs
-      shell: dmesg | tail -n 50
+      raw: dmesg | tail -n 50
       register: kernel_logs
 
     - name: Display system logs
       debug:
-        var: system_logs.stdout_lines
+        msg: "{{ system_logs.stdout_lines }}"
 
     - name: Save logs to file
       copy:

--- a/playbooks/network/unifi/get_stats.yml
+++ b/playbooks/network/unifi/get_stats.yml
@@ -4,7 +4,7 @@
   gather_facts: false
   tasks:
     - name: Get wireless stats (mca-dump)
-      shell: mca-dump
+      raw: mca-dump
       register: mca_dump
 
     - name: Parse dump for key stats
@@ -17,7 +17,7 @@
           - "Model: {{ parsed_stats.model }}"
           - "Version: {{ parsed_stats.version }}"
           - "Uptime: {{ parsed_stats.uptime }}s"
-          - "Memory: {{ parsed_stats.mem_used / 1024 / 1024 | round(2) }}MB / {{ parsed_stats.mem_total / 1024 / 1024 | round(2) }}MB"
+          - "Memory: {{ (parsed_stats.mem_used | int) / 1024 / 1024 | round(2) }}MB / {{ (parsed_stats.mem_total | int) / 1024 / 1024 | round(2) }}MB"
           - "Load: {{ parsed_stats.loadavg }}"
 
     - name: Save detailed stats to file

--- a/web/app.py
+++ b/web/app.py
@@ -3302,7 +3302,7 @@ def api_inventory_test_connection():
             inventory_path = f.name
 
         try:
-            # Run ansible ping module
+            # Try ansible ping module first (verifies Python environment)
             result = subprocess.run(
                 [
                     'ansible', hostname,
@@ -3314,6 +3314,21 @@ def api_inventory_test_connection():
                 text=True,
                 timeout=30
             )
+
+            # If ping fails, try raw module (verifies basic SSH connectivity)
+            if result.returncode != 0:
+                result = subprocess.run(
+                    [
+                        'ansible', hostname,
+                        '-i', inventory_path,
+                        '-m', 'raw',
+                        '-a', 'true',
+                        '--timeout', '10'
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=30
+                )
 
             if result.returncode == 0:
                 return jsonify({


### PR DESCRIPTION
Updates UniFi playbooks to use the `raw` module (no Python required) and enhances the inventory connection test to fallback to `raw` if `ping` fails.