### PR TITLE
Fix: Update UniFi playbooks host targeting

### DIFF
--- a/playbooks/network/unifi/get_config.yml
+++ b/playbooks/network/unifi/get_config.yml
@@ -1,6 +1,6 @@
 ---
 - name: Gather UniFi AP Configuration
-  hosts: unifi_aps
+  hosts: all
   gather_facts: false
   tasks:
     - name: Get current configuration

--- a/playbooks/network/unifi/get_logs.yml
+++ b/playbooks/network/unifi/get_logs.yml
@@ -1,6 +1,6 @@
 ---
 - name: Gather UniFi AP Logs
-  hosts: unifi_aps
+  hosts: all
   gather_facts: false
   tasks:
     - name: Get system logs

--- a/playbooks/network/unifi/get_stats.yml
+++ b/playbooks/network/unifi/get_stats.yml
@@ -1,6 +1,6 @@
 ---
 - name: Gather UniFi AP Usage Stats
-  hosts: unifi_aps
+  hosts: all
   gather_facts: false
   tasks:
     - name: Get wireless stats (mca-dump)


### PR DESCRIPTION
Changes hosts: unifi_aps to hosts: all to allow the UI target selection (limit flag) to work correctly with existing inventory groups.